### PR TITLE
Simplified fillMatrix(color) and Fixed #16.

### DIFF
--- a/minBlock.js
+++ b/minBlock.js
@@ -55,11 +55,13 @@ var minBlock = function (config) {
 
     //draws a single color square
     function drawSquare(color, matrixX, matrixY) {
-        var x = options.padding + (matrixX * squareWidth);
-        var y = options.padding + (matrixY * squareHeight);
+        var x = Math.floor(options.padding + (matrixX * squareWidth) + options.spacing);
+        var y = Math.floor(options.padding + (matrixY * squareHeight) + options.spacing);
+        var w = Math.ceil(squareWidth - options.spacing * 2);
+        var h = Math.ceil(squareHeight - options.spacing * 2);
         ctx.beginPath();
         ctx.fillStyle = color;
-        ctx.rect(x + options.spacing, y + options.spacing, squareWidth - options.spacing * 2, squareHeight - options.spacing * 2);
+        ctx.rect(x, y, w, h);
         ctx.fill();
         ctx.closePath();
     }

--- a/minBlock.js
+++ b/minBlock.js
@@ -46,11 +46,11 @@ var minBlock = function (config) {
 
     //fills entire matrix a single color
     function fillMatrix(color) {
-        for (var i = 0; i < options.blocksPerEdge; i++) {
-            for (var j = 0; j < options.blocksPerEdge; j++) {
-                drawSquare(color, j, i);
-            }
-        }
+        ctx.beginPath();
+        ctx.fillStyle = color;
+        ctx.rect(0, 0, canvasWidth, canvasHeight);
+        ctx.fill();
+        ctx.closePath();
     }
 
     //draws a single color square


### PR DESCRIPTION
1) fillMatrix(color) can just draw 1 secondary color square that includes the whole canvas area. The little primary color squares are then just drawn on it. No need to draw n^2 little squares.

2) fixed #16 by rounding off the position values and rounding up the height and width values.
Now, the code works fine if the canvas size and the number of blocks per edge are NOT divisible without remainder:
**Example:**
canvas height and width: 541
blocks per edge: 7

![download5](https://user-images.githubusercontent.com/21332313/52979832-bb028300-33d7-11e9-9611-325d4f7f36dd.png)
